### PR TITLE
def _step 수정

### DIFF
--- a/test.py
+++ b/test.py
@@ -115,8 +115,12 @@ class SongHistoryEnv(py_environment.PyEnvironment):
 
         prev = self._history.copy()
         self._history[:-1] = prev[1:]
-        self._history[-1] = item2idx.get(self.user_sequence[self._step_count + 1], 0) + 1
-
+        if self._step_count + 1 < len(self.user_sequence):
+            next_song = self.user_sequence[self._step_count + 1]
+            self._history[-1] = item2idx.get(next_song, 0) + 1
+        else:
+            self._history[-1] = 0  # 또는 padding 값
+        
         self._step_count += 1
         if self._step_count >= self._max_steps - 1:
             self._episode_ended = True


### PR DESCRIPTION
🔧 수정 전 (IndexError 발생 가능)
python
코드 복사
self._history[-1] = item2idx.get(self.user_sequence[self._step_count + 1], 0) + 1 self._step_count + 1이 self.user_sequence 길이 이상이면 리스트 범위 밖을 참조하게 되어 IndexError 발생.

예를 들어 사용자의 청취 이력이 5곡뿐인데, max_steps가 5일 경우 마지막 step에서 위 코드 실행 시 터짐.

✅ 수정 후 (안전하게 예외 처리)
python
코드 복사
if self._step_count + 1 < len(self.user_sequence):
    next_song = self.user_sequence[self._step_count + 1]
    self._history[-1] = item2idx.get(next_song, 0) + 1
else:
    self._history[-1] = 0  # 또는 padding 값